### PR TITLE
Removing package with no matching distribution, resolves #1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 paramiko==2.7.1
-pkg-resources==0.0.0
 pycparser==2.20
 PyNaCl==1.4.0
 six==1.15.0


### PR DESCRIPTION
According to pypa/pip#4022, this is a known bug resulting from Ubuntu providing incorrect metadata to pip.